### PR TITLE
fix(progress): don't display on just creating the handle

### DIFF
--- a/lua/juu/progress/handle.lua
+++ b/lua/juu/progress/handle.lua
@@ -42,9 +42,6 @@ function ProgressHandle.new(message)
   -- Load the notification config
   progress.load_config(self._raw)
 
-  -- Initial update (for begin)
-  notification.notify(progress.format_progress(self._raw))
-
   return self
 end
 


### PR DESCRIPTION
The handle should not display a notification, just because it is being created.

This makes it easier to set up multiple handles at once and then just use and dispose them if needed.

Previously each created handle would create a sticky notification, waiting to be updated and/or disposed.